### PR TITLE
Fix issue 39

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,6 @@ class Install(install):
             print("Not installing PTH file to real prefix")
             return
 
-        CMDLINE = [sys.executable, "-mpip", "install", vext_version]
-        print(CMDLINE)
-        call(CMDLINE)
         self.do_egg_install()
         self.execute(_post_install, [self], msg="Install vext files:")
 
@@ -97,7 +94,7 @@ setup(
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    setup_requires=[vext_version, "setuptools>=0.18.8"],
+    setup_requires=["setuptools>=0.18.8"],
     install_requires=[vext_version],
     data_files=[('', ["gi.vext"])]
 )


### PR DESCRIPTION
This change removes an unnecessary setup_requires entry, and the manual install of vext, from setup.py

Vext doesn't need to be in setup_requires, at least not for running sdist or the final installation (and there don't seem to be tests that require it either?).  It's enough for vext to be in install_requires.

If vext is in setup_requires, then it gets downloaded by some deep part of distutils (or something like that) when you run `pip install` on the package.  And this distutils operation is hard to customise with the arguments mentioned in stuaxo/vext#39.

Since vext is still part of install_requires, pip will install it before installing vext.gi, but in a way that supports custom arguments.  For the same reason, there's no need to manually install vext again within the custom Install.run() function.

Note that I've left the vext version unchanged in this pull request.